### PR TITLE
Add many=true to UserDetailSerializer.positions

### DIFF
--- a/api/serializers/user_serializers.py
+++ b/api/serializers/user_serializers.py
@@ -14,7 +14,7 @@ class UserSerializer(serializers.ModelSerializer):
 class UserDetailSerializer(serializers.ModelSerializer):
     from .company_position_serializers.company_position_company_serializer import CompanyPositionCompanySerializer
 
-    positions = CompanyPositionCompanySerializer(read_only=True)
+    positions = CompanyPositionCompanySerializer(many=True, read_only=True)
 
     class Meta:
         model = User


### PR DESCRIPTION
### Description
#### Fixed
- Added `many=True` to `CompanyPositionUserSerializer` for `CompanyDetailSerializer.positions`
   - This is necessary because a User has many CompanyPositions.